### PR TITLE
one_vm['one_nics'] is created from dict instance.

### DIFF
--- a/DiscoverOneVMs.py
+++ b/DiscoverOneVMs.py
@@ -55,6 +55,12 @@ def one_vm_nics(one_vm):
                 'mask': '24',
                 'mac' : nics['MAC']
                  },]
+    elif isinstance(nics, dict):
+        return [{'name': 'eth{}'.format(nics['NIC_ID']),
+                'ip': nics.get('IP'),
+                'mask': '24',
+                'mac' : nics['MAC']
+                 },]
     return None
 
 if __name__ == "__main__":


### PR DESCRIPTION
I had following error message before:

File /opt/one2netbox/./DiscoverOneVMs.py, line 184, in <module>

    if not None in one_vm['one_nics']:

TypeError: argument of type 'NoneType' is not iterable